### PR TITLE
Improvements to responder chain management

### DIFF
--- a/PARObjectObserver.m
+++ b/PARObjectObserver.m
@@ -128,25 +128,16 @@
 	callbackSelector = NULL;
 }
 
-// compiling with ARC
-#if __has_feature(objc_arc)
 - (void)dealloc
 {
 	[self invalidate];
     observedObject = nil;
     delegate = nil;
-}
-
-// compiling without ARC
-#else
-- (void)dealloc
-{
-	[self invalidate];
-    observedObject = nil;
-    delegate = nil;
+    
+    // Manual memory management:
+#if !__has_feature(objc_arc)
     [super dealloc];
-}
 #endif
-
+}
 
 @end

--- a/PARViewController.m
+++ b/PARViewController.m
@@ -11,6 +11,7 @@
 @interface PARViewController()
 @property (readwrite, retain) PARObjectObserver *nextResponderObserver;
 @property (assign, nonatomic) BOOL viewWindowObservationEnabled;
+// AppKit implementation of isViewLoaded is only available in OS X 10.10 or above, so we need to set our own flag here
 @property (assign, nonatomic) BOOL par_isViewLoaded;
 @end
 
@@ -65,7 +66,7 @@ static void * PARViewControllerContext = &PARViewControllerContext;
     }
 }
 
-+ (BOOL) accessInstanceVariablesDirectly
++ (BOOL)accessInstanceVariablesDirectly
 {
     // For the case of removing objects from the responder chain, we must prevent direct access to instance variables
     return NO;
@@ -112,8 +113,6 @@ static void * PARViewControllerContext = &PARViewControllerContext;
 - (void)loadView
 {
     [super loadView];
-    
-    // AppKit implementation of isViewLoaded is only available in OS X 10.10 or above, so we need to set our own flag here
     self.par_isViewLoaded = YES;
 }
 

--- a/PARViewController.m
+++ b/PARViewController.m
@@ -127,9 +127,9 @@ static void * PARViewControllerContext = &PARViewControllerContext;
     
     // Remove self.view.window KVO
     [self removeViewWindowObservation];
+    
     [super setView:newView];
     
-	[self patchResponderChain];
 	[self.nextResponderObserver invalidate];
 	if (newView != nil)
     {

--- a/PARViewController.m
+++ b/PARViewController.m
@@ -44,6 +44,16 @@ static void * PARViewControllerContext = &PARViewControllerContext;
 	}
 }
 
+- (void)unpatchResponderChain
+{
+    NSResponder *parentResponder = [self view];
+    
+    NSAssert(self.view.nextResponder == self, @"Our view is not actually the parent responder.");
+    
+    // Remove the current view controller from the responder chain
+    [parentResponder setNextResponder:[self nextResponder]];
+}
+
 #pragma mark - KVO
 
 - (void)removeViewWindowObservation

--- a/PARViewController.m
+++ b/PARViewController.m
@@ -139,7 +139,7 @@ static void * PARViewControllerContext = &PARViewControllerContext;
     // Add self.view.window KVO
     [self addObserver:self
            forKeyPath:@"view.window"
-              options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld
+              options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld | NSKeyValueObservingOptionInitial
               context:PARViewControllerContext];
     self.viewWindowObservationEnabled = YES;
 

--- a/PARViewController.m
+++ b/PARViewController.m
@@ -112,6 +112,8 @@ static void * PARViewControllerContext = &PARViewControllerContext;
 - (void)loadView
 {
     [super loadView];
+    
+    // AppKit implementation of isViewLoaded is only available in OS X 10.10 or above, so we need to set our own flag here
     self.par_isViewLoaded = YES;
 }
 

--- a/PARViewController.m
+++ b/PARViewController.m
@@ -10,6 +10,7 @@
 
 @interface PARViewController()
 @property (readwrite, retain) PARObjectObserver *nextResponderObserver;
+@property (assign, nonatomic) BOOL viewWindowObservationRemoved;
 @end
 
 @implementation PARViewController
@@ -18,6 +19,9 @@
 
 - (void)dealloc
 {
+    // Remove self.view.window KVO
+    [self removeViewWindowObservation];
+    
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
     self.nextResponderObserver = nil;
     #if ! __has_feature(objc_arc)
@@ -37,13 +41,38 @@
 	}
 }
 
+- (void)removeViewWindowObservation
+{
+    if (!self.viewWindowObservationRemoved)
+    {
+        [self removeObserver:self forKeyPath:@"view.window"];
+        self.viewWindowObservationRemoved = YES;
+    }
+}
+
 - (void)setView:(NSView *)newView
 {
-	[super setView:newView];
+    if (self.view == newView)
+    {
+        return;
+    }
+    
+    // Remove self.view.window KVO
+    [self removeViewWindowObservation];
+    
+    [super setView:newView];
 	[self patchResponderChain];
 	[self.nextResponderObserver invalidate];
 	if (newView != nil)
+    {
 		self.nextResponderObserver = [PARObjectObserver observerWithDelegate:self selector:@selector(nextResponderDidChange) observedKeys:@[@"nextResponder"] observedObject:[self view]];
+    }
+    
+    // Add self.view.window KVO
+    [self addObserver:self
+           forKeyPath:@"view.window"
+              options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld
+              context:nil];
 
 	// optionally observe the view frame
 	if ([self respondsToSelector:@selector(viewFrameDidChange)])


### PR DESCRIPTION
This PR aims to improve the responder chain management of PARViewController so that we (hopefully) avoid hitting the remaining hard-to-diagnose class of crashes due to the garbage data being present in the responder chain during deallocation of views, as described here: https://github.com/mekentosj/papers-mac/issues/3994

Myself and @defragged worked on this, and are confident that it is working as intended and the responder chain appears intact during adding and removing objects from it, but of course this should have a decent level of scrutiny pointed at it before merging.
